### PR TITLE
Make the use cases a little more generic

### DIFF
--- a/draft-sullivan-tls-exported-authenticator.md
+++ b/draft-sullivan-tls-exported-authenticator.md
@@ -55,13 +55,13 @@ party to be validated by the other party.
 This mechanism provides two advantages over the authentication that TLS natively
 provides:
 
-multiple identities:
+multiple identities -
 
 : Endpoints that are authoritative for multiple identities - but do not have a
   single certificate that includes all of the identities - can authenticate with
   those identities over a single connection.
 
-spontaneous authentication
+spontaneous authentication -
 
 : Endpoints can authenticate after a connection is established, in response to
   events in a higher-layer protocol, as well as integrating more context.

--- a/draft-sullivan-tls-exported-authenticator.md
+++ b/draft-sullivan-tls-exported-authenticator.md
@@ -52,15 +52,19 @@ of additional identities at any time after the handshake has completed.  This
 proof of authentication can be exported and transmitted out of band from one
 party to be validated by the other party.
 
-This mechanism is useful in the following situations:
+This mechanism provides two advantages over the authentication that TLS natively
+provides:
 
-* servers that are authoritative for multiple domains the same connection
-but do not have a certificate that is simultaneously authoritative for all
-of them
-* servers that have resources that require client authentication to access
-and need to request client authentication after the connection has started
-* clients that want to assert ownership over an identity to a server after
-a connection has been established
+multiple identities:
+
+: Endpoints that are authoritative for multiple identities - but do not have a
+  single certificate that includes all of the identities - can authenticate with
+  those identities over a single connection.
+
+spontaneous authentication
+
+: Endpoints can authenticate after a connection is established, in response to
+  events in a higher-layer protocol, as well as integrating more context.
 
 This document intends to replace much of the functionality of renegotiation
 in previous versions of TLS.  It has the advantages over renegotiation of not


### PR DESCRIPTION
Obviously there are two major features this provides:

1. multiple identities (TLS only does one)

2. spontaneous authentication, in context (TLS only allows it at the start)

So make it clear that these are the features that this provides.

The original text was a little lopsided, but the fact is that both peers can benefit from both of these features.  Whether they can and how they can will be up to the using protocol.